### PR TITLE
Handle potion metadata via PotionData

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ goals:
   daily_wheat:
     title: "&e일일 채집가"
     reset: daily
-    preset: break          # break/place/kill/mythic_kill/craft/smelt/pickup/fish/stay
+    preset: break          # preset 목록은 아래 표 참고
     when: wheat,carrots,potatoes
     target: 300
     rewards:
@@ -86,19 +86,37 @@ goals:
 | preset        | 내부 소스               | 설명                          |
 |---------------|--------------------------|-------------------------------|
 | `break`       | `block_break`            | 블록 캐기                     |
+| `harvest`     | `harvest`                | 성숙 작물 수확(최대 단계만)   |
 | `place`       | `block_place`            | 블록 놓기                     |
 | `kill`        | `mob_kill`               | 몹 처치                        |
 | `mythic_kill` | `mob_kill:mythic`        | MythicMobs ID/티어 필터       |
-| `craft`       | `craft`                   | 제작 결과물                   |
-| `smelt`       | `smelt`                   | 제련 결과물                   |
-| `pickup`      | `pickup`                  | 아이템 주움(획득)             |
-| `fish`        | `fish`                    | 낚시 성공                     |
-| `stay`        | `region_stay`             | WorldGuard 리전 **1초당 +1**  |
+| `shear`       | `shear`                  | 동물 털깎기 성공              |
+| `breed`       | `breed`                  | 플레이어가 번식시킨 동물      |
+| `tame`        | `tame`                   | 생명체 길들이기               |
+| `craft`       | `craft`                  | 제작 결과물                   |
+| `smelt`       | `smelt`                  | 제련 결과물                   |
+| `pickup`      | `pickup`                 | 아이템 주움(획득)             |
+| `fish`        | `fish`                   | 낚시 성공                     |
+| `trade`       | `trade`                  | 주민 거래 결과 수령           |
+| `enchant`     | `enchant`                | 아이템 마법 부여              |
+| `anvil`       | `anvil`                  | 모루 수리/합성 결과 수령      |
+| `smithing`    | `smithing`               | 대장장이 작업대 결과 수령    |
+| `brew`        | `brew`                   | 포션 양조(완성 병 수만큼)     |
+| `consume`     | `consume`                | 음식·포션 섭취               |
+| `distance`    | `distance`               | 이동 거리 누적 (on_foot/boat/elytra) |
+| `advancement` | `advancement`            | 어드밴스먼트 달성             |
+| `stay`        | `region_stay`            | WorldGuard 리전 **1초당 +1**  |
 
 ### 4.2 when(대상)
 - 여러 개: `diamond_ore,ancient_debris`
 - 전부 허용: `*` 또는 `any`
 - MythicMobs: `mythic_kill` + `when: BOSS_A,BOSS_B` 또는 `*`
+- 수확/털깎기/번식/길들이기: 블록·엔티티 키(`wheat`, `sheep` 등)
+- 거래: 주민 직업(`farmer`), 레벨(`master`), 조합(`farmer:master`), 숫자(`5`), `any`
+- 인챈트: `sharpness`, `mending` 등 인챈트 키 (레벨 조건은 `where.level_min/max`)
+- 모루/대장장이/양조/섭취: 결과 아이템 키 또는 포션 키(`minecraft:strong_healing`)
+- 이동: `on_foot`, `boat`, `elytra`
+- 어드밴스먼트: `minecraft:story/mine_stone`, `minecraft:story/*` 처럼 와일드카드 허용
 
 ### 4.3 where(선택 — 필터)
 ```yml
@@ -109,8 +127,66 @@ where:
   time: "06:00-23:00"
   tool: HOE              # HOE | PICKAXE | AXE ...
   y_between: "20..60"
+  level_min: 3           # 인챈트 최소 레벨
+  level_max: 5
+  merchant_profession: FARMER
+  distance_sample_ms: 250
+  distance_min_m: 0.2
+  mode: elytra           # distance 모드 강제(on_foot/boat/elytra)
 ```
 > 위 형식은 내부 DSL로 자동 변환되어 적용됩니다.
+- `level_min`, `level_max`: 인챈트 레벨 필터
+- `merchant_profession`: 거래 시 주민 직업 고정
+- `distance_sample_ms`: 이동 샘플 간 최소 시간(기본 250ms)
+- `distance_min_m`: 이동 거리 최소 허용값(기본 0.2m)
+- `mode`: distance 목표에서 강제할 이동 모드
+
+### 4.5 신규 preset 샘플
+```yml
+goals:
+  daily_harvest:
+    title: "&e일일 수확"
+    reset: daily
+    preset: harvest
+    when: wheat,carrots,potatoes
+    target: 200
+    rewards: [{ money: 600 }]
+
+  weekly_trader:
+    title: "&6주간 상인"
+    reset: weekly
+    preset: trade
+    when: any
+    target: 50
+    rewards: [{ money: 4000 }]
+
+  brewer_week:
+    title: "&d양조 달인"
+    reset: weekly
+    preset: brew
+    when: any
+    target: 64
+    rewards: [{ money: 3000 }]
+
+  elytra_runner:
+    title: "&a엘리트라 장거리"
+    reset: weekly
+    preset: distance
+    when: elytra
+    target: 20000
+    rewards: [{ money: 5000 }]
+
+  vanilla_master:
+    title: "&c바닐라 성취가"
+    type: unique
+    reset: season:2025S4
+    preset: advancement
+    when: "minecraft:story/*"
+    unique_by: advancement_key
+    target: 10
+    rewards:
+      - { cmd: "lp user %player% perm settemp cosmetic.title.master true 30d" }
+```
 
 ### 4.4 reset(초기화)
 - `daily`, `weekly`, `monthly`, `season:<ID>`, `repeat`

--- a/src/main/java/org/haemin/advancement/model/GoalDef.java
+++ b/src/main/java/org/haemin/advancement/model/GoalDef.java
@@ -33,42 +33,53 @@ public class GoalDef {
 
     public Map<String, TrackMatcher> trackMatchers = Collections.emptyMap();
     public Map<String, List<ChecklistMatcher>> checklistMatchers = Collections.emptyMap();
+    public Map<String, List<TrackSpec>> trackSpecs = Collections.emptyMap();
 
     public static final class TrackMatcher {
         private final boolean matchesAny;
         private final Set<String> values;
+        private final List<String> wildcards;
 
-        public TrackMatcher(boolean matchesAny, Set<String> values) {
+        public TrackMatcher(boolean matchesAny, Set<String> values, List<String> wildcards) {
             this.matchesAny = matchesAny;
             this.values = (values == null || values.isEmpty()) ? Collections.emptySet() : Collections.unmodifiableSet(values);
+            this.wildcards = (wildcards == null || wildcards.isEmpty()) ? Collections.emptyList() : List.copyOf(wildcards);
         }
 
         public boolean matches(String id) {
             if (matchesAny) return true;
             if (id == null || id.isEmpty()) return false;
-            return values.contains(id);
+            if (values.contains(id)) return true;
+            if (wildcards.isEmpty()) return false;
+            for (String pattern : wildcards) {
+                if (Wildcard.match(pattern, id)) return true;
+            }
+            return false;
         }
 
         public boolean matchesAny() { return matchesAny; }
 
         public Set<String> values() { return values; }
 
+        public List<String> wildcards() { return wildcards; }
+
         @Override
         public String toString() {
             return "TrackMatcher{" +
                     "matchesAny=" + matchesAny +
                     ", values=" + values +
+                    ", wildcards=" + wildcards +
                     '}';
         }
 
         @Override
-        public int hashCode() { return Objects.hash(matchesAny, values); }
+        public int hashCode() { return Objects.hash(matchesAny, values, wildcards); }
 
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (!(o instanceof TrackMatcher that)) return false;
-            return matchesAny == that.matchesAny && Objects.equals(values, that.values);
+            return matchesAny == that.matchesAny && Objects.equals(values, that.values) && Objects.equals(wildcards, that.wildcards);
         }
     }
 
@@ -112,6 +123,114 @@ public class GoalDef {
             if (this == o) return true;
             if (!(o instanceof ChecklistMatcher that)) return false;
             return index == that.index && matchesAny == that.matchesAny && Objects.equals(values, that.values);
+        }
+    }
+
+    public static final class TrackSpec {
+        private final int index;
+        private final String kind;
+        private final boolean any;
+        private final Set<String> values;
+        private final List<String> wildcards;
+        private final String preset;
+        private final int levelMin;
+        private final int levelMax;
+        private final String merchantProfession;
+        private final int distanceSampleMs;
+        private final double distanceMinMeters;
+        private final String modeFilter;
+
+        public TrackSpec(int index,
+                         String kind,
+                         boolean any,
+                         Set<String> values,
+                         List<String> wildcards,
+                         String preset,
+                         int levelMin,
+                         int levelMax,
+                         String merchantProfession,
+                         int distanceSampleMs,
+                         double distanceMinMeters,
+                         String modeFilter) {
+            this.index = index;
+            this.kind = kind;
+            this.any = any;
+            this.values = (values == null || values.isEmpty()) ? Collections.emptySet() : Collections.unmodifiableSet(values);
+            this.wildcards = (wildcards == null || wildcards.isEmpty()) ? Collections.emptyList() : List.copyOf(wildcards);
+            this.preset = preset;
+            this.levelMin = levelMin;
+            this.levelMax = levelMax;
+            this.merchantProfession = merchantProfession;
+            this.distanceSampleMs = distanceSampleMs;
+            this.distanceMinMeters = distanceMinMeters;
+            this.modeFilter = modeFilter;
+        }
+
+        public int index() { return index; }
+
+        public String kind() { return kind; }
+
+        public boolean matchesAny() { return any; }
+
+        public boolean matchesId(String id) {
+            if (any) return true;
+            if (id == null || id.isEmpty()) return false;
+            if (values.contains(id)) return true;
+            if (wildcards.isEmpty()) return false;
+            for (String pattern : wildcards) {
+                if (Wildcard.match(pattern, id)) return true;
+            }
+            return false;
+        }
+
+        public Set<String> values() { return values; }
+
+        public List<String> wildcards() { return wildcards; }
+
+        public String preset() { return preset; }
+
+        public int levelMin() { return levelMin; }
+
+        public int levelMax() { return levelMax; }
+
+        public String merchantProfession() { return merchantProfession; }
+
+        public int distanceSampleMs() { return distanceSampleMs; }
+
+        public double distanceMinMeters() { return distanceMinMeters; }
+
+        public String modeFilter() { return modeFilter; }
+    }
+
+    public static final class Wildcard {
+        public static boolean match(String pattern, String value) {
+            if (pattern == null || value == null) return false;
+            if (pattern.isEmpty()) return value.isEmpty();
+            if (!pattern.contains("*")) return pattern.equals(value);
+            String[] parts = pattern.split("\\*", -1);
+            int index = 0;
+            boolean first = true;
+            for (String part : parts) {
+                if (part.isEmpty()) {
+                    if (first) {
+                        first = false;
+                        continue;
+                    }
+                    continue;
+                }
+                int pos = value.indexOf(part, index);
+                if (pos < 0) return false;
+                if (first && !pattern.startsWith("*")) {
+                    if (pos != 0) return false;
+                }
+                index = pos + part.length();
+                first = false;
+            }
+            if (!pattern.endsWith("*")) {
+                String last = parts[parts.length - 1];
+                return value.endsWith(last);
+            }
+            return true;
         }
     }
 }

--- a/src/main/java/org/haemin/advancement/model/Progress.java
+++ b/src/main/java/org/haemin/advancement/model/Progress.java
@@ -20,6 +20,8 @@ public class Progress {
     public long ttCooldownUntil;
     public long ttBest;
 
+    public java.util.Set<String> uniques;
+
     public Progress() {}
     public Progress(long value, long target) { this.value = value; this.target = target; }
 

--- a/src/main/java/org/haemin/advancement/service/EventRouter.java
+++ b/src/main/java/org/haemin/advancement/service/EventRouter.java
@@ -1,71 +1,351 @@
 package org.haemin.advancement.service;
 
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.Ageable;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Merchant;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Villager;
+import org.bukkit.entity.WanderingTrader;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.entity.EntityBreedEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.event.entity.EntityTameEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.enchantment.EnchantItemEvent;
+import org.bukkit.event.inventory.BrewEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerAdvancementDoneEvent;
 import org.bukkit.event.player.PlayerFishEvent;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerShearEntityEvent;
+import org.bukkit.inventory.BrewerInventory;
+import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.MerchantInventory;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.potion.PotionData;
+import org.bukkit.potion.PotionType;
 import org.haemin.advancement.AdvancementPlugin;
 import org.haemin.advancement.model.GoalDef;
 import org.haemin.advancement.model.GoalType;
 import org.haemin.advancement.model.Progress;
+import org.haemin.advancement.util.Log;
 
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 public class EventRouter implements Listener {
+    private static final double DEFAULT_DISTANCE_MIN = 0.2D;
+    private static final Set<String> BOAT_TYPES = new LinkedHashSet<>(List.of(
+            "boat", "raft", "chest_boat", "chest_raft"
+    ));
+
+    private static final Method POTION_TYPE_KEY_METHOD = findPotionTypeKey();
+
     private final AdvancementPlugin plugin;
+    private final Map<UUID, DistanceState> distanceStates = new HashMap<>();
+    private final Map<UUID, Map<String, DistanceBuffer>> distanceProgress = new HashMap<>();
 
     public EventRouter(AdvancementPlugin plugin) {
         this.plugin = plugin;
+        logHook("block_break");
+        logHook("mob_kill");
+        logHook("craft");
+        logHook("fish");
+        logHook("pickup");
+        logHook("harvest");
+        logHook("shear");
+        logHook("breed");
+        logHook("tame");
+        logHook("trade");
+        logHook("enchant");
+        logHook("anvil");
+        logHook("smithing");
+        logHook("brew");
+        logHook("consume");
+        logHook("distance");
+        logHook("advancement");
+    }
+
+    private void logHook(String preset) {
+        Log.info("Hooked preset listener: " + preset);
     }
 
     @EventHandler
     public void onBreak(BlockBreakEvent e) {
         Player p = e.getPlayer();
-        String id = e.getBlock().getType().name().toLowerCase(Locale.ROOT);
-        handle(p, "block_break", id, 1);
+        Block block = e.getBlock();
+        Material type = block.getType();
+        String id = type.name().toLowerCase(Locale.ROOT);
+        TrackContext breakCtx = TrackContext.of("block_break").block(type);
+        route(p, "block_break", id, 1, breakCtx);
+
+        BlockData data = block.getBlockData();
+        if (data instanceof Ageable ageable) {
+            if (ageable.getAge() >= ageable.getMaximumAge()) {
+                TrackContext harvestCtx = TrackContext.of("harvest").block(type);
+                route(p, "harvest", id, 1, harvestCtx);
+            }
+        }
     }
 
     @EventHandler
-    public void onDeath(EntityDeathEvent e) {
+    public void onEntityDeath(EntityDeathEvent e) {
         Player killer = e.getEntity().getKiller();
         if (killer == null) return;
         String id = e.getEntityType().name().toLowerCase(Locale.ROOT);
-        handle(killer, "mob_kill", id, 1);
+        TrackContext ctx = TrackContext.of("mob_kill").entity(e.getEntityType());
+        route(killer, "mob_kill", id, 1, ctx);
     }
 
     @EventHandler
     public void onFish(PlayerFishEvent e) {
         Player p = e.getPlayer();
-        handle(p, "fish", "any", 1);
+        TrackContext ctx = TrackContext.of("fish");
+        route(p, "fish", "any", 1, ctx);
     }
 
     @EventHandler
     public void onCraft(CraftItemEvent e) {
-        if (!(e.getWhoClicked() instanceof Player)) return;
-        Player p = (Player) e.getWhoClicked();
-        ItemStack it = e.getRecipe()==null? null : e.getRecipe().getResult();
-        String id = it==null? "any" : it.getType().name().toLowerCase(Locale.ROOT);
-        int delta = it==null? 1 : Math.max(1, it.getAmount());
-        handle(p, "craft", id, delta);
+        if (!(e.getWhoClicked() instanceof Player p)) return;
+        ItemStack result = e.getRecipe() == null ? null : e.getRecipe().getResult();
+        String id = result == null ? "any" : result.getType().name().toLowerCase(Locale.ROOT);
+        int delta = result == null ? 1 : Math.max(1, result.getAmount());
+        TrackContext ctx = TrackContext.of("craft");
+        if (result != null) ctx.item(result.getType());
+        route(p, "craft", id, delta, ctx);
     }
 
     @EventHandler
     public void onPickup(EntityPickupItemEvent e) {
         Entity ent = e.getEntity();
-        if (!(ent instanceof Player)) return;
-        Player p = (Player) ent;
-        ItemStack it = e.getItem().getItemStack();
-        String id = it.getType().name().toLowerCase(Locale.ROOT);
-        int delta = Math.max(1, it.getAmount());
-        handle(p, "pickup", id, delta);
+        if (!(ent instanceof Player p)) return;
+        ItemStack stack = e.getItem().getItemStack();
+        Material type = stack.getType();
+        String id = type.name().toLowerCase(Locale.ROOT);
+        TrackContext ctx = TrackContext.of("pickup").item(type);
+        int delta = Math.max(1, stack.getAmount());
+        route(p, "pickup", id, delta, ctx);
+    }
+
+    @EventHandler
+    public void onShear(PlayerShearEntityEvent e) {
+        Player p = e.getPlayer();
+        EntityType type = e.getEntity().getType();
+        String id = type.name().toLowerCase(Locale.ROOT);
+        TrackContext ctx = TrackContext.of("shear").entity(type);
+        route(p, "shear", id, 1, ctx);
+    }
+
+    @EventHandler
+    public void onBreed(EntityBreedEvent e) {
+        Entity breeder = e.getBreeder();
+        if (!(breeder instanceof Player p)) return;
+        EntityType type = e.getEntityType();
+        String id = type.name().toLowerCase(Locale.ROOT);
+        TrackContext ctx = TrackContext.of("breed").entity(type);
+        route(p, "breed", id, 1, ctx);
+    }
+
+    @EventHandler
+    public void onTame(EntityTameEvent e) {
+        if (!(e.getOwner() instanceof Player p)) return;
+        EntityType type = e.getEntityType();
+        String id = type.name().toLowerCase(Locale.ROOT);
+        TrackContext ctx = TrackContext.of("tame").entity(type);
+        route(p, "tame", id, 1, ctx);
+    }
+
+    @EventHandler
+    public void onTrade(InventoryClickEvent e) {
+        if (!(e.getWhoClicked() instanceof Player p)) return;
+        InventoryView view = e.getView();
+        if (!(view.getTopInventory() instanceof MerchantInventory inv)) return;
+        if (e.getSlotType() != InventoryType.SlotType.RESULT) return;
+        ItemStack current = e.getCurrentItem();
+        if (current == null || current.getType().isAir()) return;
+
+        Merchant merchant = inv.getMerchant();
+        String profession = null;
+        int level = 0;
+        if (merchant instanceof Villager villager) {
+            profession = villager.getProfession().name().toLowerCase(Locale.ROOT);
+            level = villager.getVillagerLevel();
+        } else if (merchant instanceof WanderingTrader) {
+            profession = "wandering_trader";
+            level = 1;
+        }
+        String levelName = villagerLevelName(level);
+        String id = profession == null ? "any" : profession;
+        TrackContext ctx = TrackContext.of("trade").trade(profession, level, levelName).item(current.getType());
+        route(p, "trade", id, 1, ctx);
+    }
+
+    @EventHandler
+    public void onEnchant(EnchantItemEvent e) {
+        Player p = e.getEnchanter();
+        ItemStack item = e.getItem();
+        Map<Enchantment, Integer> enchants = e.getEnchantsToAdd();
+        if (enchants == null || enchants.isEmpty()) return;
+        for (Map.Entry<Enchantment, Integer> entry : enchants.entrySet()) {
+            Enchantment enchantment = entry.getKey();
+            int level = entry.getValue() == null ? 1 : entry.getValue();
+            String key = enchantment.getKey().getKey().toLowerCase(Locale.ROOT);
+            TrackContext ctx = TrackContext.of("enchant").enchant(enchantment, level);
+            if (item != null) ctx.item(item.getType());
+            route(p, "enchant", key, 1, ctx);
+        }
+    }
+
+    @EventHandler
+    public void onAnvil(InventoryClickEvent e) {
+        if (!(e.getWhoClicked() instanceof Player p)) return;
+        if (e.getView().getTopInventory().getType() != InventoryType.ANVIL) return;
+        if (e.getSlotType() != InventoryType.SlotType.RESULT) return;
+        ItemStack item = e.getCurrentItem();
+        if (item == null || item.getType().isAir()) return;
+        Material type = item.getType();
+        String id = type.name().toLowerCase(Locale.ROOT);
+        TrackContext ctx = TrackContext.of("anvil").item(type);
+        route(p, "anvil", id, 1, ctx);
+    }
+
+    @EventHandler
+    public void onSmithing(InventoryClickEvent e) {
+        if (!(e.getWhoClicked() instanceof Player p)) return;
+        if (e.getView().getTopInventory().getType() != InventoryType.SMITHING) return;
+        if (e.getSlotType() != InventoryType.SlotType.RESULT) return;
+        ItemStack item = e.getCurrentItem();
+        if (item == null || item.getType().isAir()) return;
+        Material type = item.getType();
+        String id = type.name().toLowerCase(Locale.ROOT);
+        TrackContext ctx = TrackContext.of("smithing").item(type);
+        route(p, "smithing", id, 1, ctx);
+    }
+
+    @EventHandler
+    public void onBrew(BrewEvent e) {
+        BrewerInventory inv = e.getContents();
+        if (inv == null) return;
+        List<Player> viewers = new ArrayList<>();
+        for (HumanEntity viewer : inv.getViewers()) {
+            if (viewer instanceof Player p) viewers.add(p);
+        }
+        if (viewers.isEmpty()) return;
+
+        int count = 0;
+        String key = null;
+        Material itemType = null;
+        for (int i = 0; i < 3; i++) {
+            ItemStack stack = inv.getItem(i);
+            if (stack == null || stack.getType().isAir()) continue;
+            count += Math.max(1, stack.getAmount());
+            itemType = stack.getType();
+            String potionKey = resolvePotionKey(stack);
+            if (potionKey != null) key = potionKey;
+        }
+        if (count <= 0) return;
+        String id = key == null ? (itemType == null ? "any" : itemType.name().toLowerCase(Locale.ROOT)) : key;
+        for (Player viewer : viewers) {
+            TrackContext ctx = TrackContext.of("brew");
+            if (itemType != null) ctx.item(itemType);
+            if (key != null) ctx.potion(key);
+            route(viewer, "brew", id, count, ctx);
+        }
+    }
+
+    @EventHandler
+    public void onConsume(PlayerItemConsumeEvent e) {
+        Player p = e.getPlayer();
+        ItemStack stack = e.getItem();
+        if (stack == null) return;
+        Material type = stack.getType();
+        String itemId = type.name().toLowerCase(Locale.ROOT);
+        String potionKey = resolvePotionKey(stack);
+        String id = potionKey != null ? potionKey : itemId;
+        TrackContext ctx = TrackContext.of("consume").item(type);
+        if (potionKey != null) ctx.potion(potionKey);
+        route(p, "consume", id, 1, ctx);
+    }
+
+    @EventHandler
+    public void onAdvancement(PlayerAdvancementDoneEvent e) {
+        Player p = e.getPlayer();
+        NamespacedKey key = e.getAdvancement().getKey();
+        String id = key.toString().toLowerCase(Locale.ROOT);
+        TrackContext ctx = TrackContext.of("advancement").advancement(id);
+        route(p, "advancement", id, 1, ctx);
+    }
+
+    @EventHandler
+    public void onMove(PlayerMoveEvent e) {
+        Player p = e.getPlayer();
+        Location to = e.getTo();
+        Location from = e.getFrom();
+        if (to == null || from == null) return;
+        if (from.getWorld() == null || to.getWorld() == null) return;
+        long now = System.currentTimeMillis();
+        DistanceState state = distanceStates.computeIfAbsent(p.getUniqueId(), k -> new DistanceState());
+        if (state.anchor == null || !state.anchor.getWorld().equals(to.getWorld())) {
+            state.anchor = to.clone();
+            state.lastSampleMs = now;
+            return;
+        }
+        if (from.getWorld() != to.getWorld()) {
+            state.anchor = to.clone();
+            state.lastSampleMs = now;
+            return;
+        }
+        double sq = from.distanceSquared(to);
+        if (sq < 1e-4) return;
+        if (sq > 4096) { // teleport guard
+            state.anchor = to.clone();
+            state.lastSampleMs = now;
+            return;
+        }
+        long elapsed = now - state.lastSampleMs;
+        if (elapsed < 50) return;
+        double distance = state.anchor.distance(to);
+        state.anchor = to.clone();
+        state.lastSampleMs = now;
+        if (distance <= 0) return;
+
+        String mode = distanceMode(p);
+        TrackContext base = TrackContext.of("distance").mode(mode).distance(distance).sampleMs((int) elapsed);
+        processDistance(p, base, now);
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent e) {
+        clearDistance(e.getPlayer().getUniqueId());
+    }
+
+    @EventHandler
+    public void onPlayerDeath(PlayerDeathEvent e) {
+        clearDistance(e.getEntity().getUniqueId());
     }
 
     public void signalRegionStay(Player p, String regionId) {
@@ -77,43 +357,233 @@ public class EventRouter implements Listener {
         }
     }
 
-    private void handle(Player p, String kind, String id, long delta) {
-        String normalizedKind = kind.toLowerCase(Locale.ROOT);
-        String normalizedId = id == null ? "" : id.toLowerCase(Locale.ROOT);
-        for (GoalDef d : plugin.goals().trackedBy(normalizedKind)) {
-            if (d.type == GoalType.CHECKLIST) {
-                boolean changed = false;
-                Map<String, List<GoalDef.ChecklistMatcher>> matchers = d.checklistMatchers;
-                if (matchers != null) {
-                    List<GoalDef.ChecklistMatcher> items = matchers.get(normalizedKind);
-                    if (items != null && !items.isEmpty()) {
-                        Progress pr = null;
-                        for (GoalDef.ChecklistMatcher matcher : items) {
-                            if (!matcher.matches(normalizedId)) continue;
-                            if (pr == null) pr = plugin.progress().get(p.getUniqueId(), d);
-                            if ((pr.checklistBits & matcher.bit()) != 0) continue;
-                            pr.checklistBits |= matcher.bit();
-                            pr.value = Long.bitCount(pr.checklistBits);
-                            if (!pr.completed && pr.value >= d.target) pr.completed = true;
-                            changed = true;
-                        }
-                        if (changed) plugin.progress().flushAll();
-                    }
+    private void processDistance(Player player, TrackContext base, long now) {
+        List<GoalDef> defs = List.copyOf(plugin.goals().trackedBy("distance"));
+        if (defs.isEmpty()) return;
+        for (GoalDef def : defs) {
+            List<GoalDef.TrackSpec> specs = def.trackSpecs.get("distance");
+            if (specs == null || specs.isEmpty()) continue;
+            for (GoalDef.TrackSpec spec : specs) {
+                if (!matchesDistance(spec, base)) continue;
+                DistanceBuffer buffer = distanceBuffer(player.getUniqueId(), bufferKey(def, spec));
+                if (spec.distanceSampleMs() > 0 && buffer.lastMs > 0 && now - buffer.lastMs < spec.distanceSampleMs()) {
+                    continue;
                 }
-                continue;
-            }
-
-            GoalDef.TrackMatcher matcher = d.trackMatchers.get(normalizedKind);
-            if (matcher == null || !matcher.matches(normalizedId)) continue;
-
-            if (d.type == GoalType.UNIQUE) {
-                Progress pr = plugin.progress().get(p.getUniqueId(), d);
-                pr.value += delta;
-                if (!pr.completed && pr.value >= d.target) pr.completed = true;
-                plugin.progress().flushAll();
-            } else {
-                plugin.progress().add(p, d, delta);
+                double min = spec.distanceMinMeters() > 0 ? spec.distanceMinMeters() : DEFAULT_DISTANCE_MIN;
+                if (base.distanceMeters() < min) continue;
+                buffer.lastMs = now;
+                buffer.pending += base.distanceMeters();
+                int gain = (int) Math.floor(buffer.pending);
+                if (gain <= 0) continue;
+                buffer.pending -= gain;
+                TrackContext ctx = TrackContext.of("distance").mode(base.mode()).distance(gain).sampleMs(base.sampleMs());
+                plugin.progress().increment(player, def, gain, ctx);
             }
         }
+    }
+
+    private boolean matchesDistance(GoalDef.TrackSpec spec, TrackContext ctx) {
+        String mode = ctx.mode();
+        if (spec.modeFilter() != null && !spec.modeFilter().equals(mode)) return false;
+        if (spec.matchesAny()) return true;
+        if (mode != null && spec.matchesId(mode)) return true;
+        return false;
+    }
+
+    private void route(Player player, String kind, String id, long delta, TrackContext ctx) {
+        if (player == null) return;
+        String normalizedKind = kind.toLowerCase(Locale.ROOT);
+        String normalizedId = id == null ? "" : id.toLowerCase(Locale.ROOT);
+        for (GoalDef def : plugin.goals().trackedBy(normalizedKind)) {
+            if (def.type == GoalType.CHECKLIST) {
+                handleChecklist(player, def, normalizedKind, normalizedId);
+                continue;
+            }
+            if (normalizedKind.equals("distance")) continue;
+            if (normalizedKind.equals("region_stay")) continue;
+            if (!handleSpecs(player, def, normalizedKind, normalizedId, delta, ctx)) {
+                GoalDef.TrackMatcher matcher = def.trackMatchers.get(normalizedKind);
+                if (matcher != null && matcher.matches(normalizedId)) {
+                    plugin.progress().increment(player, def, delta, ctx);
+                }
+            }
+        }
+    }
+
+    private void handleChecklist(Player player, GoalDef def, String kind, String id) {
+        boolean changed = false;
+        Map<String, List<GoalDef.ChecklistMatcher>> matchers = def.checklistMatchers;
+        if (matchers != null) {
+            List<GoalDef.ChecklistMatcher> items = matchers.get(kind);
+            if (items != null && !items.isEmpty()) {
+                Progress pr = null;
+                for (GoalDef.ChecklistMatcher matcher : items) {
+                    if (!matcher.matches(id)) continue;
+                    if (pr == null) pr = plugin.progress().get(player.getUniqueId(), def);
+                    if ((pr.checklistBits & matcher.bit()) != 0) continue;
+                    pr.checklistBits |= matcher.bit();
+                    pr.value = Long.bitCount(pr.checklistBits);
+                    if (!pr.completed && pr.value >= def.target) pr.completed = true;
+                    changed = true;
+                }
+                if (changed) plugin.progress().flushAll();
+            }
+        }
+    }
+
+    private boolean handleSpecs(Player player, GoalDef def, String kind, String id, long delta, TrackContext ctx) {
+        List<GoalDef.TrackSpec> specs = def.trackSpecs.get(kind);
+        if (specs == null || specs.isEmpty()) return false;
+        for (GoalDef.TrackSpec spec : specs) {
+            if (!matchesSpec(kind, spec, id, ctx)) continue;
+            plugin.progress().increment(player, def, delta, ctx);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean matchesSpec(String kind, GoalDef.TrackSpec spec, String id, TrackContext ctx) {
+        switch (kind) {
+            case "trade":
+                return matchesTrade(spec, ctx);
+            case "enchant":
+                return matchesEnchant(spec, ctx);
+            case "brew":
+                return matchesBrew(spec, ctx, id);
+            case "consume":
+                return matchesConsume(spec, ctx, id);
+            default:
+                return spec.matchesId(id);
+        }
+    }
+
+    private boolean matchesTrade(GoalDef.TrackSpec spec, TrackContext ctx) {
+        if (ctx == null) return false;
+        String prof = ctx.tradeProfession();
+        String levelName = ctx.tradeLevelName();
+        String numeric = ctx.tradeLevel() > 0 ? String.valueOf(ctx.tradeLevel()) : null;
+        if (!spec.matchesAny()) {
+            boolean hit = false;
+            if (prof != null && spec.matchesId(prof)) hit = true;
+            if (!hit && levelName != null && spec.matchesId(levelName)) hit = true;
+            if (!hit && prof != null && levelName != null && spec.matchesId(prof + ":" + levelName)) hit = true;
+            if (!hit && numeric != null && spec.matchesId(numeric)) hit = true;
+            if (!hit) return false;
+        }
+        if (spec.merchantProfession() != null && (prof == null || !spec.merchantProfession().equals(prof))) return false;
+        return true;
+    }
+
+    private boolean matchesEnchant(GoalDef.TrackSpec spec, TrackContext ctx) {
+        if (ctx == null) return false;
+        String key = ctx.enchantKey();
+        if (!spec.matchesId(key)) return false;
+        int level = ctx.enchantLevel();
+        if (spec.levelMin() > 0 && level < spec.levelMin()) return false;
+        if (spec.levelMax() > 0 && level > spec.levelMax()) return false;
+        return true;
+    }
+
+    private boolean matchesBrew(GoalDef.TrackSpec spec, TrackContext ctx, String id) {
+        if (spec.matchesAny()) return true;
+        if (ctx != null) {
+            if (ctx.potionKey() != null && spec.matchesId(ctx.potionKey())) return true;
+            if (ctx.itemId() != null && spec.matchesId(ctx.itemId())) return true;
+        }
+        return spec.matchesId(id);
+    }
+
+    private boolean matchesConsume(GoalDef.TrackSpec spec, TrackContext ctx, String id) {
+        if (spec.matchesAny()) return true;
+        if (ctx != null) {
+            if (ctx.itemId() != null && spec.matchesId(ctx.itemId())) return true;
+            if (ctx.potionKey() != null && spec.matchesId(ctx.potionKey())) return true;
+        }
+        return spec.matchesId(id);
+    }
+
+    private DistanceBuffer distanceBuffer(UUID uuid, String key) {
+        Map<String, DistanceBuffer> map = distanceProgress.computeIfAbsent(uuid, k -> new HashMap<>());
+        return map.computeIfAbsent(key, k -> new DistanceBuffer());
+    }
+
+    private String bufferKey(GoalDef def, GoalDef.TrackSpec spec) {
+        return def.key + "#" + spec.index();
+    }
+
+    private void clearDistance(UUID uuid) {
+        distanceStates.remove(uuid);
+        distanceProgress.remove(uuid);
+    }
+
+    private String resolvePotionKey(ItemStack stack) {
+        if (stack == null) return null;
+        Material type = stack.getType();
+        ItemMeta meta = stack.getItemMeta();
+        if (meta instanceof PotionMeta potionMeta) {
+            try {
+                PotionData data = potionMeta.getBasePotionData();
+                if (data != null) {
+                    PotionType typeEnum = data.getType();
+                    String key = potionTypeKey(typeEnum);
+                    if (key != null) return key;
+                }
+            } catch (Throwable ignored) {}
+        }
+        return type == null ? null : type.name().toLowerCase(Locale.ROOT);
+    }
+
+    private static Method findPotionTypeKey() {
+        try {
+            return PotionType.class.getMethod("getKey");
+        } catch (NoSuchMethodException ignored) {
+            return null;
+        }
+    }
+
+    private String potionTypeKey(PotionType type) {
+        if (type == null) return null;
+        if (POTION_TYPE_KEY_METHOD != null) {
+            try {
+                Object obj = POTION_TYPE_KEY_METHOD.invoke(type);
+                if (obj instanceof NamespacedKey key) {
+                    return key.toString().toLowerCase(Locale.ROOT);
+                }
+            } catch (Throwable ignored) {}
+        }
+        return type.name().toLowerCase(Locale.ROOT);
+    }
+
+    private String villagerLevelName(int level) {
+        return switch (level) {
+            case 1 -> "novice";
+            case 2 -> "apprentice";
+            case 3 -> "journeyman";
+            case 4 -> "expert";
+            case 5 -> "master";
+            default -> null;
+        };
+    }
+
+    private String distanceMode(Player player) {
+        if (player.isGliding()) return "elytra";
+        Entity vehicle = player.getVehicle();
+        if (vehicle != null) {
+            String type = vehicle.getType().name().toLowerCase(Locale.ROOT);
+            for (String boat : BOAT_TYPES) {
+                if (type.contains(boat)) return "boat";
+            }
+        }
+        return "on_foot";
+    }
+
+    private static final class DistanceState {
+        private Location anchor;
+        private long lastSampleMs;
+    }
+
+    private static final class DistanceBuffer {
+        private double pending;
+        private long lastMs;
     }
 }

--- a/src/main/java/org/haemin/advancement/service/GoalRegistry.java
+++ b/src/main/java/org/haemin/advancement/service/GoalRegistry.java
@@ -109,6 +109,7 @@ public class GoalRegistry {
 
         applySimpleDsl(def, cs);
         def.trackMatchers = buildTrackMatchers(def.track);
+        def.trackSpecs = buildTrackSpecs(def.track);
         def.checklistMatchers = buildChecklistMatchers(def.checklistItems);
         return def;
     }
@@ -117,6 +118,7 @@ public class GoalRegistry {
         if (track == null || track.isEmpty()) return Collections.emptyMap();
         Map<String, Boolean> matchAny = new HashMap<>();
         Map<String, Set<String>> values = new HashMap<>();
+        Map<String, List<String>> wildcards = new HashMap<>();
         for (Map<String, Object> entry : track) {
             Object srcObj = entry.get("source");
             if (srcObj == null) continue;
@@ -136,6 +138,9 @@ public class GoalRegistry {
             for (String part : parts) {
                 String v = part.trim();
                 if (!v.isEmpty()) set.add(v);
+                if (!v.isEmpty() && v.contains("*")) {
+                    wildcards.computeIfAbsent(kind, k -> new ArrayList<>()).add(v);
+                }
             }
         }
         if (matchAny.isEmpty() && values.isEmpty()) return Collections.emptyMap();
@@ -146,9 +151,80 @@ public class GoalRegistry {
         for (String kind : kinds) {
             boolean any = matchAny.containsKey(kind);
             Set<String> set = values.get(kind);
-            out.put(kind, new GoalDef.TrackMatcher(any, set));
+            List<String> wc = wildcards.get(kind);
+            if (set != null && !set.isEmpty()) {
+                set.removeIf(s -> s.contains("*"));
+                if (set.isEmpty()) set = null;
+            }
+            out.put(kind, new GoalDef.TrackMatcher(any, set, wc));
         }
         return out.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(out);
+    }
+
+    private Map<String, List<GoalDef.TrackSpec>> buildTrackSpecs(List<Map<String, Object>> track) {
+        if (track == null || track.isEmpty()) return Collections.emptyMap();
+        Map<String, List<GoalDef.TrackSpec>> out = new HashMap<>();
+        for (int i = 0; i < track.size(); i++) {
+            Map<String, Object> entry = track.get(i);
+            if (entry == null) continue;
+            Object srcObj = entry.get("source");
+            if (srcObj == null) continue;
+            String src = String.valueOf(srcObj).trim();
+            if (src.isEmpty()) continue;
+            String lower = src.toLowerCase(Locale.ROOT);
+            int idx = lower.indexOf(':');
+            if (idx < 0) continue;
+            String kind = lower.substring(0, idx);
+            String payload = lower.substring(idx + 1);
+            boolean any = payload.equals("*") || payload.equals("any");
+            LinkedHashSet<String> exact = new LinkedHashSet<>();
+            List<String> wild = new ArrayList<>();
+            if (!any) {
+                String[] parts = payload.split(",");
+                for (String part : parts) {
+                    String v = part.trim();
+                    if (v.isEmpty()) continue;
+                    if (v.contains("*")) wild.add(v);
+                    else exact.add(v);
+                }
+            }
+            String preset = String.valueOf(entry.getOrDefault("preset", kind));
+            int levelMin = parseInt(entry.get("level_min"), -1);
+            int levelMax = parseInt(entry.get("level_max"), -1);
+            String merchant = normalizedString(entry.get("merchant_profession"));
+            int sampleMs = parseInt(entry.get("distance_sample_ms"), 250);
+            double minMeters = parseDouble(entry.get("distance_min_m"), 0.2D);
+            String mode = normalizedString(entry.get("mode"));
+            GoalDef.TrackSpec spec = new GoalDef.TrackSpec(i, kind, any, exact, wild, preset, levelMin, levelMax, merchant, sampleMs, minMeters, mode);
+            out.computeIfAbsent(kind, k -> new ArrayList<>()).add(spec);
+        }
+        if (out.isEmpty()) return Collections.emptyMap();
+        for (Map.Entry<String, List<GoalDef.TrackSpec>> e : out.entrySet()) {
+            e.setValue(List.copyOf(e.getValue()));
+        }
+        return Collections.unmodifiableMap(out);
+    }
+
+    private int parseInt(Object obj, int def) {
+        if (obj instanceof Number) return ((Number) obj).intValue();
+        if (obj instanceof String) {
+            try { return Integer.parseInt(((String) obj).trim()); } catch (Exception ignored) {}
+        }
+        return def;
+    }
+
+    private double parseDouble(Object obj, double def) {
+        if (obj instanceof Number) return ((Number) obj).doubleValue();
+        if (obj instanceof String) {
+            try { return Double.parseDouble(((String) obj).trim()); } catch (Exception ignored) {}
+        }
+        return def;
+    }
+
+    private String normalizedString(Object obj) {
+        if (obj == null) return null;
+        String s = String.valueOf(obj).trim();
+        return s.isEmpty() ? null : s.toLowerCase(Locale.ROOT);
     }
 
     private Map<String, List<GoalDef.ChecklistMatcher>> buildChecklistMatchers(List<Map<String, Object>> checklistItems) {
@@ -188,7 +264,11 @@ public class GoalRegistry {
     }
 
     private void registerIndex(GoalDef def, Map<String, LinkedHashSet<GoalDef>> indexBuilder) {
-        if (def.trackMatchers != null) {
+        if (def.trackSpecs != null) {
+            for (String kind : def.trackSpecs.keySet()) {
+                indexBuilder.computeIfAbsent(kind, k -> new LinkedHashSet<>()).add(def);
+            }
+        } else if (def.trackMatchers != null) {
             for (String kind : def.trackMatchers.keySet()) {
                 indexBuilder.computeIfAbsent(kind, k -> new LinkedHashSet<>()).add(def);
             }
@@ -201,6 +281,17 @@ public class GoalRegistry {
     }
 
     private void applySimpleDsl(GoalDef def, ConfigurationSection cs) {
+        ConfigurationSection whereSection = cs.getConfigurationSection("where");
+        Map<String, Object> extras = new LinkedHashMap<>();
+        if (whereSection != null) {
+            if (whereSection.isSet("level_min")) extras.put("level_min", whereSection.getInt("level_min"));
+            if (whereSection.isSet("level_max")) extras.put("level_max", whereSection.getInt("level_max"));
+            if (whereSection.isSet("merchant_profession")) extras.put("merchant_profession", whereSection.getString("merchant_profession"));
+            if (whereSection.isSet("distance_sample_ms")) extras.put("distance_sample_ms", whereSection.getInt("distance_sample_ms"));
+            if (whereSection.isSet("distance_min_m")) extras.put("distance_min_m", whereSection.getDouble("distance_min_m"));
+            if (whereSection.isSet("mode")) extras.put("mode", whereSection.getString("mode"));
+        }
+
         if (def.track == null || def.track.isEmpty()) {
             String preset = cs.getString("preset", null);
             String when = cs.getString("when", null);
@@ -209,13 +300,20 @@ public class GoalRegistry {
                 if (src != null) {
                     Map<String, Object> e = new LinkedHashMap<>();
                     e.put("source", src);
+                    e.put("preset", preset.trim().toLowerCase(Locale.ROOT));
+                    if (!extras.isEmpty()) {
+                        for (Map.Entry<String, Object> ex : extras.entrySet()) {
+                            e.put(ex.getKey(), ex.getValue());
+                        }
+                    }
                     def.track = List.of(e);
-                    if ("mythic_kill".equalsIgnoreCase(preset) && def.uniqueBy == null) def.uniqueBy = "mythic_id";
+                    if ("mythic_kill".equalsIgnoreCase(preset) && (def.uniqueBy == null || def.uniqueBy.isBlank())) def.uniqueBy = "mythic_id";
+                    if ("advancement".equalsIgnoreCase(preset) && (def.uniqueBy == null || def.uniqueBy.isBlank() || "entity_type".equalsIgnoreCase(def.uniqueBy))) def.uniqueBy = "advancement_key";
                 }
             }
         }
-        if ((def.filter == null || def.filter.isBlank()) && cs.isConfigurationSection("where")) {
-            ConfigurationSection w = cs.getConfigurationSection("where");
+        if ((def.filter == null || def.filter.isBlank()) && whereSection != null) {
+            ConfigurationSection w = whereSection;
             List<String> parts = new ArrayList<>();
             String world = w.getString("world", null);
             if (world != null && !world.isBlank()) {
@@ -264,6 +362,18 @@ public class GoalRegistry {
         if (p.equals("pickup")) return "pickup:" + list;
         if (p.equals("fish")) return "fish:" + list;
         if (p.equals("stay") || p.equals("region_stay")) return "region_stay:" + list;
+        if (p.equals("harvest")) return "harvest:" + list;
+        if (p.equals("shear")) return "shear:" + list;
+        if (p.equals("breed")) return "breed:" + list;
+        if (p.equals("tame")) return "tame:" + list;
+        if (p.equals("trade")) return "trade:" + list;
+        if (p.equals("enchant")) return "enchant:" + list;
+        if (p.equals("anvil")) return "anvil:" + list;
+        if (p.equals("smithing")) return "smithing:" + list;
+        if (p.equals("brew")) return "brew:" + list;
+        if (p.equals("consume")) return "consume:" + list;
+        if (p.equals("distance")) return "distance:" + list;
+        if (p.equals("advancement")) return "advancement:" + list;
         return null;
     }
 

--- a/src/main/java/org/haemin/advancement/service/TrackContext.java
+++ b/src/main/java/org/haemin/advancement/service/TrackContext.java
@@ -1,0 +1,150 @@
+package org.haemin.advancement.service;
+
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
+import org.bukkit.enchantments.Enchantment;
+
+import java.util.Locale;
+
+public class TrackContext {
+    private final String source;
+    private String blockId;
+    private Material blockType;
+    private String entityId;
+    private EntityType entityType;
+    private String itemId;
+    private Material itemType;
+    private String enchantKey;
+    private Enchantment enchantment;
+    private int enchantLevel;
+    private String advancementKey;
+    private double distanceMeters;
+    private String mode;
+    private int sampleMs;
+    private String tradeProfession;
+    private int tradeLevel;
+    private String tradeLevelName;
+    private String potionKey;
+
+    private TrackContext(String source) {
+        this.source = source == null ? "" : source.toLowerCase(Locale.ROOT);
+    }
+
+    public static TrackContext of(String source) {
+        return new TrackContext(source);
+    }
+
+    public TrackContext block(Material type) {
+        this.blockType = type;
+        if (type != null) this.blockId = type.name().toLowerCase(Locale.ROOT);
+        return this;
+    }
+
+    public TrackContext blockId(String id) {
+        this.blockId = id == null ? null : id.toLowerCase(Locale.ROOT);
+        return this;
+    }
+
+    public TrackContext entity(EntityType type) {
+        this.entityType = type;
+        if (type != null) this.entityId = type.name().toLowerCase(Locale.ROOT);
+        return this;
+    }
+
+    public TrackContext entityId(String id) {
+        this.entityId = id == null ? null : id.toLowerCase(Locale.ROOT);
+        return this;
+    }
+
+    public TrackContext item(Material type) {
+        this.itemType = type;
+        if (type != null) this.itemId = type.name().toLowerCase(Locale.ROOT);
+        return this;
+    }
+
+    public TrackContext itemId(String id) {
+        this.itemId = id == null ? null : id.toLowerCase(Locale.ROOT);
+        return this;
+    }
+
+    public TrackContext enchant(Enchantment enchantment, int level) {
+        this.enchantment = enchantment;
+        this.enchantLevel = level;
+        if (enchantment != null) this.enchantKey = enchantment.getKey().getKey().toLowerCase(Locale.ROOT);
+        return this;
+    }
+
+    public TrackContext enchantKey(String key, int level) {
+        this.enchantKey = key == null ? null : key.toLowerCase(Locale.ROOT);
+        this.enchantLevel = level;
+        return this;
+    }
+
+    public TrackContext advancement(String key) {
+        this.advancementKey = key == null ? null : key.toLowerCase(Locale.ROOT);
+        return this;
+    }
+
+    public TrackContext distance(double meters) {
+        this.distanceMeters = meters;
+        return this;
+    }
+
+    public TrackContext mode(String mode) {
+        this.mode = mode == null ? null : mode.toLowerCase(Locale.ROOT);
+        return this;
+    }
+
+    public TrackContext sampleMs(int ms) {
+        this.sampleMs = ms;
+        return this;
+    }
+
+    public TrackContext trade(String profession, int level, String levelName) {
+        this.tradeProfession = profession == null ? null : profession.toLowerCase(Locale.ROOT);
+        this.tradeLevel = level;
+        this.tradeLevelName = levelName == null ? null : levelName.toLowerCase(Locale.ROOT);
+        return this;
+    }
+
+    public TrackContext potion(String key) {
+        this.potionKey = key == null ? null : key.toLowerCase(Locale.ROOT);
+        return this;
+    }
+
+    public String source() { return source; }
+    public String blockId() { return blockId; }
+    public Material blockType() { return blockType; }
+    public String entityId() { return entityId; }
+    public EntityType entityType() { return entityType; }
+    public String itemId() { return itemId; }
+    public Material itemType() { return itemType; }
+    public String enchantKey() { return enchantKey; }
+    public Enchantment enchantment() { return enchantment; }
+    public int enchantLevel() { return enchantLevel; }
+    public String advancementKey() { return advancementKey; }
+    public double distanceMeters() { return distanceMeters; }
+    public String mode() { return mode; }
+    public int sampleMs() { return sampleMs; }
+    public String tradeProfession() { return tradeProfession; }
+    public int tradeLevel() { return tradeLevel; }
+    public String tradeLevelName() { return tradeLevelName; }
+    public String potionKey() { return potionKey; }
+
+    public String valueFor(String key) {
+        if (key == null || key.isEmpty()) return null;
+        String normalized = key.toLowerCase(Locale.ROOT);
+        return switch (normalized) {
+            case "block", "block_type" -> blockId;
+            case "entity", "entity_type" -> entityId;
+            case "item", "item_type" -> itemId;
+            case "enchant", "enchant_key" -> enchantKey;
+            case "advancement", "advancement_key" -> advancementKey;
+            case "mode" -> mode;
+            case "trade_profession" -> tradeProfession;
+            case "trade_level" -> tradeLevelName != null ? tradeLevelName : (tradeLevel <= 0 ? null : String.valueOf(tradeLevel));
+            case "potion", "potion_key" -> potionKey != null ? potionKey : itemId;
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/org/haemin/advancement/service/YamlPlayerStore.java
+++ b/src/main/java/org/haemin/advancement/service/YamlPlayerStore.java
@@ -44,6 +44,7 @@ public class YamlPlayerStore {
         p.ttAccum = c.getLong(base + "tt_accum", 0);
         p.ttCooldownUntil = c.getLong(base + "tt_cd_until", 0);
         p.ttBest = c.getLong(base + "tt_best", 0);
+        p.uniques = new java.util.LinkedHashSet<>(c.getStringList(base + "uniques"));
         return p;
     }
 
@@ -64,6 +65,7 @@ public class YamlPlayerStore {
                 c.set(base + "tt_accum", p.ttAccum);
                 c.set(base + "tt_cd_until", p.ttCooldownUntil);
                 c.set(base + "tt_best", p.ttBest);
+                c.set(base + "uniques", p.uniques == null ? null : new java.util.ArrayList<>(p.uniques));
                 File f = file(uuid);
                 File parent = f.getParentFile();
                 if (!parent.exists()) parent.mkdirs();

--- a/src/main/java/org/haemin/advancement/util/GoalLore.java
+++ b/src/main/java/org/haemin/advancement/util/GoalLore.java
@@ -4,13 +4,32 @@ import org.haemin.advancement.model.GoalDef;
 import org.haemin.advancement.model.GoalType;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 public class GoalLore {
+    private static final Map<String, String> PRESET_LORE = Map.ofEntries(
+            Map.entry("harvest", "&7- 성숙 작물 수확"),
+            Map.entry("shear", "&7- 동물 털깎기"),
+            Map.entry("breed", "&7- 동물 번식 성공"),
+            Map.entry("tame", "&7- 생명체 길들이기"),
+            Map.entry("trade", "&7- 주민 거래 결과 수령"),
+            Map.entry("enchant", "&7- 아이템 마법 부여"),
+            Map.entry("anvil", "&7- 모루 작업 완료"),
+            Map.entry("smithing", "&7- 대장장이 작업대 합성"),
+            Map.entry("brew", "&7- 포션 양조 완료"),
+            Map.entry("consume", "&7- 음식/포션 섭취"),
+            Map.entry("distance", "&7- 이동 거리 누적"),
+            Map.entry("advancement", "&7- 어드밴스먼트 달성")
+    );
+
     public static List<String> describe(GoalDef d) {
         if (d.lore != null && !d.lore.isEmpty()) return d.lore;
         List<String> out = new ArrayList<>();
+        out.addAll(presetLore(d));
         if (d.type == GoalType.COUNTER || d.type == GoalType.UNIQUE) {
             if (d.track != null) {
                 for (Map<String,Object> e : d.track) {
@@ -35,5 +54,19 @@ public class GoalLore {
             out.add("&7- 리셋: &f" + r);
         }
         return out;
+    }
+
+    private static List<String> presetLore(GoalDef d) {
+        if (d.trackSpecs == null || d.trackSpecs.isEmpty()) return List.of();
+        Set<String> lines = new LinkedHashSet<>();
+        for (List<GoalDef.TrackSpec> specs : d.trackSpecs.values()) {
+            for (GoalDef.TrackSpec spec : specs) {
+                String preset = spec.preset();
+                if (preset == null || preset.isEmpty()) continue;
+                String text = PRESET_LORE.get(preset.toLowerCase(Locale.ROOT));
+                if (text != null) lines.add(text);
+            }
+        }
+        return lines.isEmpty() ? List.of() : List.copyOf(lines);
     }
 }

--- a/src/main/resources/readme.md
+++ b/src/main/resources/readme.md
@@ -47,7 +47,7 @@ goals:
   daily_wheat:
     title: "&e일일 채집가"
     reset: daily
-    preset: break          # break/place/kill/mythic_kill/craft/smelt/pickup/fish/stay
+    preset: break          # preset 목록은 아래 안내 참고
     when: wheat,carrots,potatoes
     target: 300
     rewards:
@@ -57,19 +57,37 @@ goals:
 
 ### 2.1 preset 목록
 - `break`       : 블록 캐기 (`block_break`)
+- `harvest`     : 성숙 작물 수확 (`harvest`)
 - `place`       : 블록 놓기 (`block_place`)
 - `kill`        : 몹 처치 (`mob_kill`)
 - `mythic_kill` : MythicMobs 처치 (`mob_kill:mythic`)
+- `shear`       : 동물 털깎기 (`shear`)
+- `breed`       : 동물 번식 (`breed`)
+- `tame`        : 길들이기 (`tame`)
 - `craft`       : 제작 결과물 (`craft`)
 - `smelt`       : 제련 결과물 (`smelt`)
 - `pickup`      : 아이템 주움 (`pickup`)
 - `fish`        : 낚시 성공 (`fish`)
+- `trade`       : 주민 거래 결과 수령 (`trade`)
+- `enchant`     : 아이템 마법 부여 (`enchant`)
+- `anvil`       : 모루 수리/합성 결과 (`anvil`)
+- `smithing`    : 대장장이 작업대 결과 (`smithing`)
+- `brew`        : 포션 양조 완료 (`brew`)
+- `consume`     : 음식/포션 섭취 (`consume`)
+- `distance`    : 이동 거리 누적 (`distance`)
+- `advancement` : 어드밴스먼트 달성 (`advancement`)
 - `stay`        : 리전 체류 1초당 +1 (`region_stay`)
 
 ### 2.2 when(대상)
 - 여러 개: `diamond_ore,ancient_debris`
 - 전부 허용: `*` 또는 `any`
 - MythicMobs: `mythic_kill` + `when: BOSS_A,BOSS_B` 또는 `*`
+- 수확/털깎기/번식/길들이기: 블록·엔티티 키(`wheat`, `sheep` 등)
+- 거래: 주민 직업(`farmer`), 레벨(`master`), 조합(`farmer:master`), 숫자(`5`), `any`
+- 인챈트: `sharpness`, `mending` 등 인챈트 키 (레벨 조건은 `where.level_min/max`)
+- 모루/대장장이/양조/섭취: 결과 아이템 또는 포션 키(`minecraft:strong_healing`)
+- 이동: `on_foot`, `boat`, `elytra`
+- 어드밴스먼트: `minecraft:story/mine_stone`, `minecraft:story/*` 와일드카드 허용
 
 ### 2.3 reset(초기화)
 - `daily`, `weekly`, `monthly`, `season:<ID>`, `repeat`
@@ -85,6 +103,66 @@ where:
   time: "06:00-23:00"
   tool: HOE              # HOE | PICKAXE | AXE ...
   y_between: "20..60"
+  level_min: 3
+  level_max: 5
+  merchant_profession: FARMER
+  distance_sample_ms: 250
+  distance_min_m: 0.2
+  mode: elytra
+```
+
+> 위 형식은 내부 DSL로 자동 변환되어 적용됩니다.
+- `level_min`, `level_max`: 인챈트 레벨 필터
+- `merchant_profession`: 거래 시 특정 직업만 허용
+- `distance_sample_ms`: 이동 샘플 최소 간격(기본 250ms)
+- `distance_min_m`: 이동 거리 최소 단위(기본 0.2m)
+- `mode`: distance 목표의 이동 모드 강제(on_foot/boat/elytra)
+
+### 2.5 신규 preset 샘플
+```yml
+goals:
+  daily_harvest:
+    title: "&e일일 수확"
+    reset: daily
+    preset: harvest
+    when: wheat,carrots,potatoes
+    target: 200
+    rewards: [{ money: 600 }]
+
+  weekly_trader:
+    title: "&6주간 상인"
+    reset: weekly
+    preset: trade
+    when: any
+    target: 50
+    rewards: [{ money: 4000 }]
+
+  brewer_week:
+    title: "&d양조 달인"
+    reset: weekly
+    preset: brew
+    when: any
+    target: 64
+    rewards: [{ money: 3000 }]
+
+  elytra_runner:
+    title: "&a엘리트라 장거리"
+    reset: weekly
+    preset: distance
+    when: elytra
+    target: 20000
+    rewards: [{ money: 5000 }]
+
+  vanilla_master:
+    title: "&c바닐라 성취가"
+    type: unique
+    reset: season:2025S4
+    preset: advancement
+    when: "minecraft:story/*"
+    unique_by: advancement_key
+    target: 10
+    rewards:
+      - { cmd: "lp user %player% perm settemp cosmetic.title.master true 30d" }
 ```
 
 ---


### PR DESCRIPTION
## Summary
- fall back to reflective potion key lookup so builds remain compatible with Paper 1.20.1
- expose potion/potion_key tokens from tracking context for unique goal handling

## Testing
- `mvn -DskipTests package` *(fails: cannot reach https://repo.maven.apache.org/maven2 to download maven-resources-plugin 3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68d018df7ee48322ab8fcf7c67d35c9a